### PR TITLE
misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,27 @@ Orcastra is a Proof-of-Concept (PoC) job queue designed for processing tasks (ca
 
 ## Getting Started
 
-_(Instructions on how to set up and run the PoC will go here.)_
+This project requires Rust **nightly** and a running **Redis** instance.
+
+1.  **Install/Switch to Nightly Toolchain:**
+    If you don't have it, install `rustup` first. Then, in the project directory, run:
+    ```bash
+    rustup override set nightly
+    ```
+
+2.  **Start Redis:**
+    The simplest way is using Docker:
+    ```bash
+    docker run -d --name orcastra-redis -p 6379:6379 redis
+    ```
+    Ensure Redis is running on the default port (`6379`) at `localhost`.
+
+3.  **Run the Project:**
+    Execute the main example using Cargo:
+    ```bash
+    cargo run
+    ```
+    This will compile and run the example tasks defined in `src/main.rs`. You should see output indicating task submission and processing via Redis streams.
 
 ## Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,20 @@
 #![feature(trait_alias)]
 
-pub mod task;
-pub mod worker;
-pub mod processors;
 pub mod messages;
+pub mod processors;
+pub mod task;
 pub mod types;
+pub mod worker;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
 
     #[test]
     fn it_works() {
         let result = "We don't need tests where we are swimming to the top";
-        assert_eq!(result, "We don't need tests where we are swimming to the top");
+        assert_eq!(
+            result,
+            "We don't need tests where we are swimming to the top"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 use kameo::prelude::*;
-use orcastra::messages::*;
-use orcastra::worker::Worker;
 use orcastra::worker::RegisterTask;
-use tracing_subscriber;
+use orcastra::worker::Worker;
 
 #[tokio::main]
 async fn main() {
@@ -13,7 +11,7 @@ async fn main() {
     tracing::subscriber::set_global_default(subscriber).expect("Failed to set subscriber");
     let redis_url = "redis://localhost:6379";
 
-    let mut worker = Worker::new(redis_url.to_string());
+    let worker = Worker::new(redis_url.to_string());
     let worker_actor = Worker::spawn(worker);
     worker_actor.wait_for_startup().await;
 
@@ -22,16 +20,19 @@ async fn main() {
     let task1_name = "StringTask".to_string();
     let task1_future = Box::pin(async move {
         println!("StringTask starting...");
-        println!("Task variable: {}", task_variable);
+        println!("Task variable: {task_variable}");
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         println!("StringTask finished!");
         "Hello from StringTask!".to_string()
     });
 
-    let task1 = worker_actor.ask(RegisterTask {
-        task_name: task1_name.clone(),
-        task_future: task1_future,
-    }).await.unwrap();
+    let task1 = worker_actor
+        .ask(RegisterTask {
+            task_name: task1_name.clone(),
+            task_future: task1_future,
+        })
+        .await
+        .unwrap();
 
     let task2_name = "IntegerTask".to_string();
     let task2_future = Box::pin(async move {
@@ -41,11 +42,13 @@ async fn main() {
         println!("IntegerTask finished!");
         result
     });
-    let task2 = worker_actor.ask(RegisterTask {
-        task_name: task2_name.clone(),
-        task_future: task2_future,
-    }).await.unwrap();
-
+    let task2 = worker_actor
+        .ask(RegisterTask {
+            task_name: task2_name.clone(),
+            task_future: task2_future,
+        })
+        .await
+        .unwrap();
 
     task1.submit().await;
     task2.submit().await;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -50,6 +50,19 @@ pub enum OrcaStates {
     Scheduled,
 }
 
+// Implement the Display trait
+impl std::fmt::Display for OrcaStates {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OrcaStates::Running => write!(f, "Running"),
+            OrcaStates::Completed => write!(f, "Completed"),
+            OrcaStates::Failed => write!(f, "Failed"),
+            OrcaStates::Submitted => write!(f, "Submitted"),
+            OrcaStates::Scheduled => write!(f, "Scheduled"),
+        }
+    }
+}
+
 impl OrcaStates {
     pub fn from_string(s: &str) -> Option<OrcaStates> {
         match s {
@@ -61,16 +74,8 @@ impl OrcaStates {
             _ => None,
         }
     }
-    pub fn display(&self) -> String {
-        match self {
-            OrcaStates::Running => "Running".to_string(),
-            OrcaStates::Completed => "Completed".to_string(),
-            OrcaStates::Failed => "Failed".to_string(),
-            OrcaStates::Submitted => "Submitted".to_string(),
-            OrcaStates::Scheduled => "Scheduled".to_string(),
-        }
-    }
 }
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TransitionState {
     pub task_name: String,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,8 +1,7 @@
-use kameo::prelude::*;
-use serde::{Serialize, Deserialize};
 use crate::types::TaskData;
+use kameo::prelude::*;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use crate::task::RunState;
 
 // Define StartTask message
 #[derive(Debug, Clone)]
@@ -27,7 +26,7 @@ pub struct TaskCompleted {
 }
 
 #[derive(Reply, Debug, Clone)]
-pub struct MatriarchReply  {
+pub struct MatriarchReply {
     pub success: bool,
 }
 
@@ -42,7 +41,7 @@ pub struct MatriarchMessage<M> {
     pub recipient: ActorType,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub enum OrcaStates {
     Running,
     Completed,
@@ -62,7 +61,7 @@ impl OrcaStates {
             _ => None,
         }
     }
-    pub fn to_string(&self) -> String {
+    pub fn display(&self) -> String {
         match self {
             OrcaStates::Running => "Running".to_string(),
             OrcaStates::Completed => "Completed".to_string(),
@@ -79,7 +78,6 @@ pub struct TransitionState {
     pub new_state: OrcaStates,
 }
 
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ActorType {
     Orca,
@@ -88,8 +86,6 @@ pub enum ActorType {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum MessageType {
-
     Worker,
     Processor,
 }
-

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -65,8 +65,7 @@ impl Message<MatriarchMessage<TransitionState>> for Worker {
             ActorType::Processor => {
                 info!(
                     "→ → {}:{} → → ",
-                    message.message.task_id,
-                    message.message.new_state.display()
+                    message.message.task_id, message.message.new_state
                 );
                 if let Some(proc) = &self.processor {
                     match proc.ask(message).await {
@@ -86,11 +85,7 @@ impl Message<MatriarchMessage<TransitionState>> for Worker {
             }
             ActorType::Orca => {
                 let task_id = message.message.task_id;
-                info!(
-                    "← ← {}:{} ← ← ",
-                    task_id,
-                    message.message.new_state.display()
-                );
+                info!("← ← {}:{} ← ← ", task_id, message.message.new_state);
                 if let Some(recipient) = self.running_tasks.get(&task_id) {
                     match recipient.forward_matriarch_request(message).await {
                         Ok(reply) => reply,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,13 +1,13 @@
-use uuid::Uuid;
-use std::collections::HashMap;
-use crate::processors::redis::Processor;
-use crate::task::{RegisteredTask, TaskRunner, TaskHandle};
 use crate::messages::*;
+use crate::processors::redis::Processor;
+use crate::task::Run;
+use crate::task::{RegisteredTask, TaskHandle, TaskRunner};
+use crate::types::TaskFuture;
 use crate::types::TaskResult;
 use kameo::prelude::*;
-use crate::task::Run;
-use crate::types::TaskFuture;
+use std::collections::HashMap;
 use tracing::info;
+use uuid::Uuid;
 
 pub struct Worker {
     id: Uuid,
@@ -15,35 +15,37 @@ pub struct Worker {
     pub registered_tasks: HashMap<String, Box<dyn TaskRunner>>,
     pub running_tasks: HashMap<Uuid, Box<dyn Run>>,
     processor: Option<ActorRef<Processor>>,
-} 
+}
 
 impl Worker {
     pub fn new(url: String) -> Self {
-        let id = Uuid::new_v4();   
-        Self { 
-            id, 
+        let id = Uuid::new_v4();
+        Self {
+            id,
             url,
-            running_tasks: HashMap::new(), 
+            running_tasks: HashMap::new(),
             registered_tasks: HashMap::new(),
             processor: None,
         }
-    }   
+    }
 
     pub fn register_task<R>(&mut self, task: RegisteredTask<R>)
-    where 
+    where
         R: TaskResult,
     {
         let name = task.name.clone();
         self.registered_tasks.insert(name, Box::new(task));
-
     }
-} 
+}
 
 impl Actor for Worker {
     type Args = Self;
     type Error = WorkerError;
 
-    async fn on_start(mut args: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, WorkerError>  {
+    async fn on_start(
+        mut args: Self::Args,
+        actor_ref: ActorRef<Self>,
+    ) -> Result<Self, WorkerError> {
         info!("Worker starting: {}", args.id);
         let processor = Processor::spawn(Processor::new(args.id, &args.url, actor_ref).await);
         args.processor = Some(processor);
@@ -57,37 +59,48 @@ impl Message<MatriarchMessage<TransitionState>> for Worker {
     async fn handle(
         &mut self,
         message: MatriarchMessage<TransitionState>,
-        _ctx: &mut Context<Self, Self::Reply>
+        _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         match message.recipient {
             ActorType::Processor => {
-                info!("→ → {}:{} → → ", message.message.task_id, message.message.new_state.to_string());
+                info!(
+                    "→ → {}:{} → → ",
+                    message.message.task_id,
+                    message.message.new_state.display()
+                );
                 if let Some(proc) = &self.processor {
                     match proc.ask(message).await {
                         Ok(reply) => reply,
                         Err(e) => {
-                            eprintln!("Error asking processor: {}", e);
+                            eprintln!("Error asking processor: {e}");
                             MatriarchReply { success: false }
                         }
                     }
                 } else {
-                    eprintln!("Processor not available for task: {}", message.message.task_id);
+                    eprintln!(
+                        "Processor not available for task: {}",
+                        message.message.task_id
+                    );
                     MatriarchReply { success: false }
                 }
             }
             ActorType::Orca => {
-                let task_id_clone = message.message.task_id.clone(); 
-                info!("← ← {}:{} ← ← ", task_id_clone, message.message.new_state.to_string());
-                if let Some(recipient) = self.running_tasks.get(&task_id_clone) {
+                let task_id = message.message.task_id;
+                info!(
+                    "← ← {}:{} ← ← ",
+                    task_id,
+                    message.message.new_state.display()
+                );
+                if let Some(recipient) = self.running_tasks.get(&task_id) {
                     match recipient.forward_matriarch_request(message).await {
                         Ok(reply) => reply,
                         Err(e) => {
-                            eprintln!("Error asking orca task {}: {}", task_id_clone, e);
+                            eprintln!("Error asking orca task {task_id}: {e}");
                             MatriarchReply { success: false }
                         }
                     }
                 } else {
-                    eprintln!("Orca task {} not found or not running", task_id_clone);
+                    eprintln!("Orca task {task_id} not found or not running");
                     MatriarchReply { success: false }
                 }
             }
@@ -100,20 +113,22 @@ pub struct RegisterTask<R> {
     pub task_future: TaskFuture<R>,
 }
 
-
 impl<R: TaskResult> Message<RegisterTask<R>> for Worker {
     type Reply = Result<TaskHandle, WorkerError>;
 
     async fn handle(
         &mut self,
         message: RegisterTask<R>,
-        ctx: &mut Context<Self, Self::Reply>
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let task_name = message.task_name.clone();
         let worker_ref = ctx.actor_ref();
         let task = RegisteredTask::new(task_name.clone(), message.task_future, worker_ref.clone());
         self.register_task(task);
-        Ok(TaskHandle { name: task_name, worker_ref: worker_ref.clone() })
+        Ok(TaskHandle {
+            name: task_name,
+            worker_ref: worker_ref.clone(),
+        })
     }
 }
 
@@ -123,35 +138,37 @@ impl Message<SubmitTask> for Worker {
     async fn handle(
         &mut self,
         message: SubmitTask,
-        _ctx: &mut Context<Self, Self::Reply>
+        _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let task_id = Uuid::new_v4();
-        if let Some(_orca) = self.registered_tasks.get_mut(&message.task_name) {
-            info!("Submitting task: {}:{}", message.task_name, task_id);
-            let res = self.processor.as_ref().unwrap().ask(MatriarchMessage {
+        let _orca = self.registered_tasks.get_mut(&message.task_name).unwrap();
+        info!("Submitting task: {}:{}", message.task_name, task_id);
+        let _res = self
+            .processor
+            .as_ref()
+            .unwrap()
+            .ask(MatriarchMessage {
                 message: TransitionState {
                     task_name: message.task_name,
-                    task_id: task_id,
+                    task_id,
                     new_state: OrcaStates::Submitted,
                 },
                 recipient: ActorType::Processor,
-            }).await;
-            Ok(())
-        } else {
-            Err(WorkerError(format!("Task {} not registered", message.task_name)))
-        }
+            })
+            .await;
+        Ok(())
     }
 }
 
 // --- Implement Handler for StartTask ---
 impl Message<RunTask> for Worker {
     // Reply indicates success/failure of starting
-    type Reply = Result<(), WorkerError>; 
+    type Reply = Result<(), WorkerError>;
 
     async fn handle(
         &mut self,
         message: RunTask,
-        ctx: &mut Context<Self, Self::Reply>
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let name = &message.task_name;
 
@@ -161,25 +178,29 @@ impl Message<RunTask> for Worker {
             let worker_ref = ctx.actor_ref();
             match spawner.run(id, worker_ref).await {
                 Ok(recipient) => {
- 
                     self.running_tasks.insert(id, recipient);
-                    let _ = self.processor.as_ref().unwrap().tell(MatriarchMessage {
-                        message: TransitionState {
-                            task_name: name.clone(),
-                            task_id: id,
-                            new_state: OrcaStates::Running,
-                        },
-                        recipient: ActorType::Orca,
-                    }).await;
+                    let _ = self
+                        .processor
+                        .as_ref()
+                        .unwrap()
+                        .tell(MatriarchMessage {
+                            message: TransitionState {
+                                task_name: name.clone(),
+                                task_id: id,
+                                new_state: OrcaStates::Running,
+                            },
+                            recipient: ActorType::Orca,
+                        })
+                        .await;
                     Ok(())
                 }
                 Err(e) => {
-                    eprintln!("Failed to spawn task {}: {}", name, e);
-                    Err(WorkerError(format!("Failed to spawn task {}: {}", name, e)))
+                    eprintln!("Failed to spawn task {name}: {e}");
+                    Err(WorkerError(format!("Failed to spawn task {name}: {e}")))
                 }
             }
         } else {
-            Err(WorkerError(format!("Task {} not registered", name)))
+            Err(WorkerError(format!("Task {name} not registered")))
         }
     }
 }


### PR DESCRIPTION
Fixes runtime errors where `TaskRun` crashed due to invalid state transition requests. Timing conflicts between internal task completion and state updates from Redis (`MatriarchMessage<TransitionState>`) caused requests like `Completed -> Running`.
`TaskRun::transition_to_state` now validates transitions against the current `RunState`, logging and ignoring invalid/redundant requests. The `TaskCompleted` handler also now checks for `RunState::Running` before attempting completion. the thinking is this makes `TaskRun` state handling robust against message timing issues.

<details>

## copilot slop

This pull request introduces several updates to improve code maintainability, enhance error handling, and add functionality for task state management in the Orcastra project. Key changes include updates to the README for setup instructions, refactoring of state transitions, and improvements to error handling and logging.

### Documentation Updates:
* Updated `README.md` to include detailed setup instructions for using the Rust nightly toolchain, running a Redis instance, and running the project via Cargo.

### State Management Enhancements:
* Refactored `TaskRun` state transitions in `src/task.rs` to ignore redundant state change requests, log invalid transitions with detailed error messages, and ensure valid transitions are logged as successful. Added error handling for worker notifications during state transitions. [[1]](diffhunk://#diff-321b82c33ff18ed6d3c1bf8234e19f198fa32f0422a4137a56a00bc72d3114a9L75-R138) [[2]](diffhunk://#diff-321b82c33ff18ed6d3c1bf8234e19f198fa32f0422a4137a56a00bc72d3114a9L130-L146)

### Error Handling and Logging Improvements:
* Updated error handling in `src/processors/redis.rs` to use `_` for unused results and improved error messages with structured logging (e.g., `{e}` instead of `{:?}`). [[1]](diffhunk://#diff-f36e3ba924e0572b51889930d25ead5935a734977cbebf268827fd56a46c349fL61-R61) [[2]](diffhunk://#diff-f36e3ba924e0572b51889930d25ead5935a734977cbebf268827fd56a46c349fL161-R162) [[3]](diffhunk://#diff-f36e3ba924e0572b51889930d25ead5935a734977cbebf268827fd56a46c349fL182-R182) [[4]](diffhunk://#diff-f36e3ba924e0572b51889930d25ead5935a734977cbebf268827fd56a46c349fL191-R191) [[5]](diffhunk://#diff-f36e3ba924e0572b51889930d25ead5935a734977cbebf268827fd56a46c349fL335-R335)

### Code Simplification and Formatting:
* Simplified and formatted code across multiple files, including `src/main.rs`, `src/task.rs`, and `src/messages.rs`, by using modern Rust syntax (e.g., `{variable}` formatting, removing redundant references, and adhering to Rust's idiomatic practices). [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL25-R35) [[2]](diffhunk://#diff-321b82c33ff18ed6d3c1bf8234e19f198fa32f0422a4137a56a00bc72d3114a9L19-R23) [[3]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL65-L82)

### New Features:
* Added a `Display` trait implementation for the `OrcaStates` enum in `src/messages.rs` for better readability when logging state transitions. Removed the redundant `to_string` method. [[1]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fR53-R65) [[2]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL65-L82)

</details>